### PR TITLE
fix: address some small memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CFLAGS:= $(CFLAGS) -std=c++20 -fPIC
+CFLAGS:= $(CFLAGS) -std=c++20 -fPIC -gdwarf-4
 SMLFLAGS = -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio
 
 SRC_DIR = src
@@ -41,11 +41,15 @@ test: $(TEST_EXECUTABLE)
 	./$(TEST_EXECUTABLE)
 	rm $(TEST_EXECUTABLE)
 
+memory: $(TEST_EXECUTABLE)
+	valgrind --leak-check=yes ./$(TEST_EXECUTABLE)
+	rm $(TEST_EXECUTABLE)
+
 clean:
-	rm -f $(OBJ_FILES) $(TEST_EXECUTABLE) $(LIB_FILE)
+	rm -f $(SRC_OBJ_FILES) $(TEST_EXECUTABLE) $(LIB_FILE)
 
 format:
-	clang-format -i $(SRC_FILES) $(TEST_FILES) $(INC_DIR)/*.h
+	clang-format -i $(SRC_FILES) $(TEST_LIB_FILES) $(SUITES_FILES) $(INC_DIR)/*.h
 
 tidy:
-	clang-tidy --fix --fix-errors --fix-notes $(SRC_FILES) $(TEST_FILES) -- $(CFLAGS) -I$(INC_DIR)
+	clang-tidy --fix --fix-errors --fix-notes $(SRC_FILES) $(TEST_LIB_FILES) $(SUITES_FILES) -- $(CFLAGS) -I$(INC_DIR)

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ test: $(TEST_EXECUTABLE)
 	rm $(TEST_EXECUTABLE)
 
 memory: $(TEST_EXECUTABLE)
-	valgrind --leak-check=yes ./$(TEST_EXECUTABLE)
+	valgrind --track-origins=yes --leak-check=full ./$(TEST_EXECUTABLE)
 	rm $(TEST_EXECUTABLE)
 
 clean:
-	rm -f $(SRC_OBJ_FILES) $(TEST_EXECUTABLE) $(LIB_FILE)
+	rm -f $(SRC_OBJ_FILES) $(SUITES_OBJ_FILES) $(TEST_LIB_OBJ_FILES) $(TEST_EXECUTABLE) $(LIB_FILE)
 
 format:
 	clang-format -i $(SRC_FILES) $(TEST_LIB_FILES) $(SUITES_FILES) $(INC_DIR)/*.h

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -5,28 +5,31 @@
 #include "Colors.h"
 #include "Vector.h"
 
+using namespace std;
+
 namespace df {
 
 class Frame {
  private:
-  int width;
-  int height;
-  std::string frame_str;
+  int width = 0;
+  int height = 0;
+  string content = "";
 
  public:
   Frame();
-  Frame(int w, int h, std::string frame_str);
+  Frame(int w, int h, string content);
 
   void setWidth(int w);
-  auto getWidth() const -> int;
+  [[nodiscard]] auto getWidth() const -> int;
 
   void setHeight(int h);
-  auto getHeight() const -> int;
+  [[nodiscard]] auto getHeight() const -> int;
 
-  void setFrameString(std::string frame_str);
-  std::string getFrameString() const;
+  void setFrameString(string content);
+  [[nodiscard]] auto getFrameString() const -> string;
 
   // Draw the frame centered at the given position with the given color
-  auto draw(Vector position, Color color, char transparencyChar) const -> int;
+  [[nodiscard]] auto draw(Vector position, Color color,
+                          char transparencyChar) const -> int;
 };
 }  // namespace df

--- a/include/Sprite.h
+++ b/include/Sprite.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "Colors.h"
 #include "Frame.h"
@@ -14,21 +15,21 @@ enum Slowdown {
 
 class Sprite {
  private:
-  int width;
-  int height;
-  int max_frame_count;
-  int frame_count;
-  int slowdown;
-  Color color;
-  Frame* frames;
-  std::string label;
-  char transparency_char;
-  Sprite();
+  int width = 0;
+  int height = 0;
+  int maxFrameCount = 0;
+  int frameCount = 0;
+  int slowdown = NO_SLOWDOWN;
+  Color color = COLOR_DEFAULT;
+  std::vector<Frame> frames = {};
+  std::string label = "";
+  char transparencyChar = ' ';
 
  public:
   ~Sprite();
-  Sprite(int max_frames);
+  Sprite(int maxFrames = 0);
   Sprite(const Sprite& other);
+  auto operator==(const Sprite& other) const -> bool;
 
   void setWidth(int width);
   [[nodiscard]] auto getWidth() const -> int;
@@ -40,7 +41,7 @@ class Sprite {
   [[nodiscard]] auto getColor() const -> Color;
 
   void setLabel(std::string label);
-  auto getLabel() const -> std::string;
+  [[nodiscard]] auto getLabel() const -> std::string;
 
   void setSlowdown(int slowdown);
   [[nodiscard]] auto getSlowdown() const -> int;
@@ -48,9 +49,9 @@ class Sprite {
   void setTransparencyChar(char transparency_char);
   [[nodiscard]] auto getTransparencyChar() const -> char;
 
-  [[nodiscard]] auto getFrameCount() const -> int;
   auto addFrame(Frame frame) -> int;
   [[nodiscard]] auto getFrame(int frame_number) const -> Frame;
+  [[nodiscard]] auto getFrameCount() const -> int;
 
   [[nodiscard]] auto draw(int frame_number, Vector position) const -> int;
 };

--- a/include/SpriteParser.h
+++ b/include/SpriteParser.h
@@ -17,6 +17,6 @@ class SpriteParser {
                           int *height, int *slowdown, Color *color) -> int;
 
  public:
-  static auto parseSprite(string filename, string label) -> Sprite *;
+  static auto parseSprite(string filename, string label) -> Sprite;
 };
 }  // namespace df

--- a/include/SpriteParser.h
+++ b/include/SpriteParser.h
@@ -7,14 +7,16 @@
 #include "Frame.h"
 #include "Sprite.h"
 
+using namespace std;
+
 namespace df {
 class SpriteParser {
  private:
-  static std::string getLine(std::ifstream *file_stream);
-  static auto parseHeader(std::ifstream *file_stream, int *frames, int *width,
+  static auto getLine(ifstream *file_stream) -> string;
+  static auto parseHeader(ifstream *file_stream, int *frames, int *width,
                           int *height, int *slowdown, Color *color) -> int;
 
  public:
-  static auto parseSprite(std::string filename, std::string label) -> Sprite *;
+  static auto parseSprite(string filename, string label) -> Sprite *;
 };
 }  // namespace df

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -5,17 +5,15 @@
 #include "LogManager.h"
 #include "Vector.h"
 
-namespace df {
-Frame::Frame() {
-  this->width = 0;
-  this->height = 0;
-  this->frame_str = "";
-}
+using namespace std;
 
-Frame::Frame(int w, int h, std::string frame_str) {
+namespace df {
+Frame::Frame() = default;
+
+Frame::Frame(int w, int h, string content) {
   this->width = w;
   this->height = h;
-  this->frame_str = frame_str;
+  this->content = content;
 }
 
 void Frame::setWidth(int w) { this->width = w; }
@@ -24,14 +22,12 @@ auto Frame::getWidth() const -> int { return this->width; }
 void Frame::setHeight(int w) { this->height = w; }
 auto Frame::getHeight() const -> int { return this->height; }
 
-void Frame::setFrameString(std::string frame_str) {
-  this->frame_str = frame_str;
-}
-auto Frame::getFrameString() const -> std::string { return this->frame_str; }
+void Frame::setFrameString(string content) { this->content = content; }
+auto Frame::getFrameString() const -> string { return this->content; }
 
 auto Frame::draw(Vector position, Color color, char transparencyChar) const
   -> int {
-  if (this->width <= 0 || this->height <= 0 || this->frame_str.empty()) {
+  if (this->width <= 0 || this->height <= 0 || this->content.empty()) {
     LM.writeLog("Frame::draw(): Cannot draw empty frame");
     return -1;
   }
@@ -42,7 +38,7 @@ auto Frame::draw(Vector position, Color color, char transparencyChar) const
   for (int i = 0; i < this->height; i++) {
     for (int j = 0; j < this->width; j++) {
       Vector temp(startX + j, startY + i);
-      char ch = this->frame_str[i * this->width + j];
+      char ch = this->content[i * this->width + j];
 
       if (ch == transparencyChar) continue;
 

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -70,11 +70,14 @@ void GameManager::run() {
   long int loopTime = 0;
   long int steps = 0;
 
+  EventStep step(0);
+
   while (!gameOver) {
     clock->delta();
 
     // Send a step event to all Objects
-    onEvent(new EventStep(++steps));
+    step.setStepCount(++steps);
+    onEvent(&step);
 
     IM.getInput();
     WM.update();

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -131,31 +131,36 @@ void InputManager::getInput() const {
 
   if (win == nullptr) return;
 
-  while (win->pollEvent(event)) {
-    Keyboard::Key key;
-    Mouse::Button btn;
-    Vector pos;
+  EventKeyboard keyEvent;
+  EventMouse mouseEvent;
 
+  while (win->pollEvent(event)) {
     switch (event.type) {
       case sf::Event::KeyPressed:
-        key = fromSFMLKeyCode(event.key.code);
-        onEvent(
-          new df::EventKeyboard(key, df::EventKeyboardAction::KEY_PRESSED));
+        keyEvent.setKey(fromSFMLKeyCode(event.key.code));
+        keyEvent.setKeyboardAction(df::EventKeyboardAction::KEY_PRESSED);
+        onEvent(&keyEvent);
         break;
       case sf::Event::KeyReleased:
-        key = fromSFMLKeyCode(event.key.code);
-        onEvent(
-          new df::EventKeyboard(key, df::EventKeyboardAction::KEY_RELEASED));
+        keyEvent.setKey(fromSFMLKeyCode(event.key.code));
+        keyEvent.setKeyboardAction(df::EventKeyboardAction::KEY_RELEASED);
+        onEvent(&keyEvent);
         break;
       case sf::Event::MouseMoved:
-        pos = Vector(event.mouseMove.x, event.mouseMove.y);
-        btn = fromSFMLMouseButton(event.mouseButton.button);
-        onEvent(new df::EventMouse(df::EventMouseAction::MOVED, btn, pos));
+        mouseEvent.setMouseAction(df::EventMouseAction::MOVED);
+        mouseEvent.setMouseButton(
+          fromSFMLMouseButton(event.mouseButton.button));
+        mouseEvent.setMousePosition(
+          Vector(event.mouseMove.x, event.mouseMove.y));
+        onEvent(&mouseEvent);
         break;
       case sf::Event::MouseButtonPressed:
-        pos = Vector(event.mouseMove.x, event.mouseMove.y);
-        btn = fromSFMLMouseButton(event.mouseButton.button);
-        onEvent(new df::EventMouse(df::EventMouseAction::CLICKED, btn, pos));
+        mouseEvent.setMouseAction(df::EventMouseAction::CLICKED);
+        mouseEvent.setMouseButton(
+          fromSFMLMouseButton(event.mouseButton.button));
+        mouseEvent.setMousePosition(
+          Vector(event.mouseMove.x, event.mouseMove.y));
+        onEvent(&mouseEvent);
         break;
       case sf::Event::Closed:
         GM.shutDown();

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -15,7 +15,7 @@ Object::Object() {
 }
 
 Object::~Object() {
-  // Resources for this object are freed in WorldManager::shutDown
+  // Resources for this object are freed in WorldManager::shutDown/update
   WM.removeObject(this);
 }
 

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -56,13 +56,7 @@ auto ResourceManager::loadSprite(std::string filename, std::string label)
     return -1;
   }
 
-  Sprite* sprite = SpriteParser::parseSprite(filename, label);
-
-  if (sprite == nullptr) {
-    LM.writeLog("ResourceManager::loadSprite(): could not parse sprite '%s'.",
-                label.c_str());
-    return -1;
-  }
+  auto* sprite = new Sprite(SpriteParser::parseSprite(filename, label));
 
   this->sprite[this->spriteCount] = sprite;
   this->spriteCount++;

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -7,44 +7,49 @@
 #include "Vector.h"
 
 namespace df {
-Sprite::Sprite(int max_frames) {
-  this->width = 0;
-  this->height = 0;
-  this->max_frame_count = max_frames;
-  this->frame_count = 0;
-  this->slowdown = NO_SLOWDOWN;
-  this->color = COLOR_DEFAULT;
-  this->frames = new Frame[this->max_frame_count];
-  this->label = "";
-  this->transparency_char = ' ';
+Sprite::Sprite(int maxFrames) {
+  this->maxFrameCount = maxFrames;
+  this->frames = std::vector<Frame>(maxFrames);
 }
 
-Sprite::~Sprite() { delete[] this->frames; }
+Sprite::Sprite(const Sprite& other) {
+  this->width = other.width;
+  this->height = other.height;
+  this->maxFrameCount = other.maxFrameCount;
+  this->frameCount = other.frameCount;
+  this->slowdown = other.slowdown;
+  this->color = other.color;
+  this->label = other.label;
+  this->transparencyChar = other.transparencyChar;
+  this->frames = other.frames;
+}
+
+Sprite::~Sprite() = default;
 
 auto Sprite::addFrame(Frame frame) -> int {
-  if (this->frame_count >= this->max_frame_count) {
+  if (this->frameCount >= this->maxFrameCount) {
     LM.writeLog("Sprite::addFrame(): Cannot add frame, maximum (%d) reached.",
-                this->max_frame_count);
+                this->maxFrameCount);
     return -1;
   }
 
-  this->frames[this->frame_count] = frame;
-  this->frame_count++;
+  this->frames[this->frameCount] = frame;
+  this->frameCount++;
 
   return 0;
 }
 
-auto Sprite::getFrame(int frame_number) const -> Frame {
-  if (frame_number < 0 || frame_number >= this->frame_count) {
+auto Sprite::getFrame(int frameNumber) const -> Frame {
+  if (frameNumber < 0 || frameNumber >= this->frameCount) {
     LM.writeLog("Sprite::getFrame(): Invalid frame number (%d) with %d frames.",
-                frame_number, this->frame_count);
+                frameNumber, this->frameCount);
     return {};
   }
 
-  return this->frames[frame_number];
+  return this->frames[frameNumber];
 }
 
-auto Sprite::getFrameCount() const -> int { return this->frame_count; }
+auto Sprite::getFrameCount() const -> int { return this->frameCount; }
 
 void Sprite::setWidth(int width) { this->width = width; }
 auto Sprite::getWidth() const -> int { return this->width; }
@@ -61,20 +66,29 @@ auto Sprite::getLabel() const -> std::string { return this->label; }
 void Sprite::setSlowdown(int slowdown) { this->slowdown = slowdown; }
 auto Sprite::getSlowdown() const -> int { return this->slowdown; }
 
-void Sprite::setTransparencyChar(char c) { this->transparency_char = c; }
+void Sprite::setTransparencyChar(char c) { this->transparencyChar = c; }
 auto Sprite::getTransparencyChar() const -> char {
-  return this->transparency_char;
+  return this->transparencyChar;
 }
 
-auto Sprite::draw(int frame_number, Vector position) const -> int {
-  if (frame_number < 0 || frame_number >= this->frame_count) {
+auto Sprite::draw(int frameNumber, Vector position) const -> int {
+  if (frameNumber < 0 || frameNumber >= this->frameCount) {
     LM.writeLog("Sprite::draw(): Invalid frame number (%d) with %d frames.",
-                frame_number, this->frame_count);
+                frameNumber, this->frameCount);
     return -1;
   }
 
-  return this->frames[frame_number].draw(position, this->color,
-                                         this->transparency_char);
+  return this->frames[frameNumber].draw(position, this->color,
+                                        this->transparencyChar);
+}
+
+auto Sprite::operator==(const Sprite& other) const -> bool {
+  return this->width == other.width && this->height == other.height &&
+         this->maxFrameCount == other.maxFrameCount &&
+         this->frameCount == other.frameCount &&
+         this->slowdown == other.slowdown && this->color == other.color &&
+         this->label == other.label &&
+         this->transparencyChar == other.transparencyChar;
 }
 
 }  // namespace df

--- a/src/SpriteParser.cpp
+++ b/src/SpriteParser.cpp
@@ -7,82 +7,51 @@
 #include "LogManager.h"
 #include "Sprite.h"
 
+using namespace std;
+
 namespace df {
-auto SpriteParser::getLine(std::ifstream* file_stream) -> std::string {
-  std::string line;
-  getline(*file_stream, line);
+auto SpriteParser::getLine(ifstream* file) -> string {
+  string line;
+  getline(*file, line);
   line.erase(
-    std::remove_if(line.begin(), line.end(), [](char c) { return c == '\r'; }),
+    remove_if(line.begin(), line.end(), [](char c) { return c == '\r'; }),
     line.end());
   return line;
 }
 
-auto SpriteParser::parseHeader(std::ifstream* file_stream, int* frames,
-                               int* width, int* height, int* slowdown,
-                               Color* color) -> int {
-  for (int i = 0; i < 5; i++) {
-    auto line = getLine(file_stream);
-    switch (i) {
-      case 0:
-        *frames = std::stoi(line);
-        break;
-      case 1:
-        *width = std::stoi(line);
-        break;
-      case 2:
-        *height = std::stoi(line);
-        break;
-      case 3:
-        *slowdown = std::stoi(line);
-        break;
-      case 4:
-        *color = fromColorString(line);
-        break;
-      default:
-        break;
-    }
-  }
-
-  return 0;
-}
-
-auto SpriteParser::parseSprite(std::string filename, std::string label)
-  -> Sprite* {
-  std::ifstream file(filename);
+auto SpriteParser::parseSprite(string filename, string label) -> Sprite {
+  ifstream file(filename);
 
   if (!file.is_open()) {
     LM.writeLog("SpriteParser::parseSprite(): Could not open file '%s'.",
                 filename.c_str());
-    return nullptr;
+    return {};
   }
 
-  int frameCount, width, height, slowdown;
-  Color color;
+  // Order of these lines matters! Do not change!
+  int frames = stoi(getLine(&file));
+  int width = stoi(getLine(&file));
+  int height = stoi(getLine(&file));
+  int slowdown = stoi(getLine(&file));
+  Color color = fromColorString(getLine(&file));
 
-  if (parseHeader(&file, &frameCount, &width, &height, &slowdown, &color) !=
-      0) {
-    LM.writeLog("SpriteParser::parseSprite(): Could not parse header.");
-    return nullptr;
-  }
+  Sprite sprite(frames);
+  sprite.setLabel(label);
+  sprite.setWidth(width);
+  sprite.setHeight(height);
+  sprite.setSlowdown(slowdown);
+  sprite.setColor(color);
 
-  auto* sprite = new Sprite(frameCount);
-  sprite->setLabel(label);
-  sprite->setWidth(width);
-  sprite->setHeight(height);
-  sprite->setSlowdown(slowdown);
-  sprite->setColor(color);
-
-  for (int i = 0; i < frameCount; i++) {
+  for (int i = 0; i < frames; i++) {
     if (!file.good()) {
       LM.writeLog(
         "SpriteParser::parseSprite(): Unexpected end of file at frame "
         "%d.",
         i);
-      delete sprite;
-      return nullptr;
+      return {};
     }
 
-    std::string frameString;
+    string frameString;
 
     for (int j = 0; j < height; j++) {
       auto line = getLine(&file);
@@ -91,14 +60,13 @@ auto SpriteParser::parseSprite(std::string filename, std::string label)
           "SpriteParser::parseSpriteBody(): Invalid line length "
           "for frame %d, line %d, expected %d got %d.",
           i, j, width, line.length());
-        delete sprite;
-        return nullptr;
+        return {};
       }
 
       frameString += line;
     }
 
-    sprite->addFrame(Frame(width, height, frameString));
+    sprite.addFrame(Frame(width, height, frameString));
   }
 
   return sprite;

--- a/src/SpriteParser.cpp
+++ b/src/SpriteParser.cpp
@@ -1,7 +1,6 @@
 #include "SpriteParser.h"
 
 #include <fstream>
-#include <iostream>
 #include <string>
 
 #include "Colors.h"

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -1,7 +1,6 @@
 #include "Vector.h"
 
 #include <cmath>
-#include <cstdio>
 #include <string>
 
 #include "utils.h"

--- a/src/WorldManager.cpp
+++ b/src/WorldManager.cpp
@@ -183,11 +183,11 @@ auto WorldManager::markForDelete(Object* o) -> int {
 }
 
 void WorldManager::draw() {
-  auto iterator = new ObjectListIterator(&this->updates);
+  auto iterator = ObjectListIterator(&this->updates);
 
   for (int i = 0; i <= MAX_ALTITUDE; i++) {
-    for (iterator->first(); !iterator->isDone(); iterator->next()) {
-      auto object = iterator->currentObject();
+    for (iterator.first(); !iterator.isDone(); iterator.next()) {
+      auto object = iterator.currentObject();
       if (object != nullptr && object->getAltitude() == i &&
           intersects(object->getWorldBox(), this->view)) {
         object->draw();

--- a/test/suites/Animation_test.cpp
+++ b/test/suites/Animation_test.cpp
@@ -9,7 +9,7 @@
 void setSprite_test() {
   Animation animation;
   RM.loadSprite("test/fixtures/correct.txt", "sprite");
-  Sprite *sprite = RM.getSprite(" sprite ");
+  Sprite *sprite = RM.getSprite("sprite");
   animation.setSprite(sprite);
 
   int result = assert("sets sprite", animation.getSprite() == sprite);

--- a/test/suites/ObjectList_test.cpp
+++ b/test/suites/ObjectList_test.cpp
@@ -9,20 +9,21 @@ void ObjectList_fullList_test() {
   Object item;
 
   for (int i = 0; i < MAX_SIZE; i++) {
-    subject.insert(new Object);
+    Object obj;
+    subject.insert(&obj);
   }
 
   assert("is full", subject.isFull());
   assert_int("has MAX_SIZE elements", subject.getCount(), MAX_SIZE);
-  assert_fail("errors upon adding", subject.insert(new Object));
+  assert_fail("errors upon adding", subject.insert(&item));
 }
 
 void ObjectList_manyItems_test() {
   ObjectList subject;
-  Object item;
+  Object item, item2, item3;
   subject.insert(&item);
-  subject.insert(new Object);
-  subject.insert(new Object);
+  subject.insert(&item2);
+  subject.insert(&item3);
   assert_int("has 3 elements", subject.getCount(), 3);
   assert("is not empty", !subject.isEmpty());
   assert("is not full", !subject.isFull());
@@ -35,7 +36,9 @@ void ObjectList_manyItems_test() {
 
 void ObjectList_oneItem_test() {
   ObjectList subject;
-  subject.insert(new Object);
+  Object o;
+
+  subject.insert(&o);
   assert_int("has one element", subject.getCount(), 1);
   assert("is not empty", !subject.isEmpty());
   assert("is not full", !subject.isFull());
@@ -43,19 +46,20 @@ void ObjectList_oneItem_test() {
 
 void ObjectList_emptyList_test() {
   ObjectList subject;
+  Object o;
+
   assert_int("has no elements", subject.getCount(), 0);
   assert("is empty", subject.isEmpty());
   assert("is not full", !subject.isFull());
-
-  assert_fail("errors upon removing", subject.remove(new Object));
+  assert_fail("errors upon removing", subject.remove(&o));
 }
 
 void ObjectList_find_test() {
   ObjectList subject;
-  Object item;
+  Object item, item2;
   subject.insert(&item);
   assert_int("finds item", subject.find(&item), 0);
-  assert_int("does not find item", subject.find(new Object), -1);
+  assert_int("does not find item", subject.find(&item2), -1);
 }
 
 void ObjectList_test() {

--- a/test/suites/Object_test.cpp
+++ b/test/suites/Object_test.cpp
@@ -100,23 +100,27 @@ void Object_eventSubscription_test() {
   assert_ok("subscribes to Keyboard", IM.subscribe(&obj, KEYBOARD_EVENT));
   assert_ok("subscribes to Mouse", IM.subscribe(&obj, MSE_EVENT));
 
-  WM.onEvent(new EventCollision());
+  EventCollision collision;
+  WM.onEvent(&collision);
   assert_int("responds to Collision",
              Object_eventSubscription_test_emittedCount[COLLISION_EVENT], 1);
-
-  WM.onEvent(new EventOut());
+  EventOut out;
+  WM.onEvent(&out);
   assert_int("responds to Out",
              Object_eventSubscription_test_emittedCount[OUT_EVENT], 1);
 
-  GM.onEvent(new EventStep());
+  EventStep step;
+  GM.onEvent(&step);
   assert_int("responds to Step",
              Object_eventSubscription_test_emittedCount[STEP_EVENT], 1);
 
-  IM.onEvent(new EventKeyboard());
+  EventKeyboard keyboard;
+  IM.onEvent(&keyboard);
   assert_int("responds to Keyboard",
              Object_eventSubscription_test_emittedCount[KEYBOARD_EVENT], 1);
 
-  IM.onEvent(new EventMouse());
+  EventMouse mouse;
+  IM.onEvent(&mouse);
   assert_int("responds to Mouse",
              Object_eventSubscription_test_emittedCount[MSE_EVENT], 1);
 }

--- a/test/suites/SpriteParser_test.cpp
+++ b/test/suites/SpriteParser_test.cpp
@@ -4,43 +4,51 @@
 #include "Colors.h"
 
 using namespace df;
+using namespace std;
 
-void makeFile(std::string filename, std::string content) {
-  std::ofstream file(filename);
+void makeFile(string filename, string content) {
+  ofstream file(filename);
   file << content;
   file.close();
 }
 
 void SpriteParser_test() {
-  Sprite* sprite =
+  Sprite sprite =
     SpriteParser::parseSprite("test/fixtures/correct.txt", "test_sprite");
 
-  assert("parses successfully", sprite != nullptr);
-  if (sprite != nullptr) {
-    assert_string("label is correct", sprite->getLabel(), "test_sprite");
-    assert_int("frame count is correct", sprite->getFrameCount(), 2);
-    assert_int("width is correct", sprite->getWidth(), 3);
-    assert_int("height is correct", sprite->getHeight(), 4);
-    assert_int("slowdown is correct", sprite->getSlowdown(), 2);
-    assert_int("color is correct", sprite->getColor(), BLUE);
-  }
+  assert_string("label is correct", sprite.getLabel(), "test_sprite");
+  assert_int("frame count is correct", sprite.getFrameCount(), 2);
+  assert_int("width is correct", sprite.getWidth(), 3);
+  assert_int("height is correct", sprite.getHeight(), 4);
+  assert_int("slowdown is correct", sprite.getSlowdown(), 2);
+  assert_int("color is correct", sprite.getColor(), BLUE);
 
-  sprite =
-    SpriteParser::parseSprite("test/fixtures/missing-frame.txt", "test_sprite");
-  assert("returns null with missing frames", sprite == nullptr);
+  test("validations", []() {
+    auto sprite = SpriteParser::parseSprite("test/fixtures/missing-frame.txt",
+                                            "test_sprite");
+    assert("returns null with missing frames", sprite == Sprite());
 
-  sprite =
-    SpriteParser::parseSprite("test/fixtures/wrong-width.txt", "test_sprite");
-  assert("returns null with incorrect width", sprite == nullptr);
+    sprite =
+      SpriteParser::parseSprite("test/fixtures/wrong-width.txt", "test_sprite");
+    assert("returns null with incorrect width", sprite == Sprite());
 
-  sprite =
-    SpriteParser::parseSprite("test/fixtures/wrong-height.txt", "test_sprite");
-  assert("returns null with incorrect height", sprite == nullptr);
+    sprite = SpriteParser::parseSprite("test/fixtures/wrong-height.txt",
+                                       "test_sprite");
+    assert("returns null with incorrect height", sprite == Sprite());
+  });
 
-  makeFile("carriage.txt",
-           "2\r\n3\r\n3\r\n2\r\nblue\r\n***\r\n***\r\n***\r\n***\r\n@@@\r\n@@@"
-           "\r\n@@@\r\n@@@");
-  sprite = SpriteParser::parseSprite("carriage.txt", "test_sprite");
-  assert("handles \\r", sprite != nullptr);
-  remove("carriage.txt");
+  test("handles carriage return", []() {
+    makeFile(
+      "carriage.txt",
+      "2\r\n3\r\n3\r\n2\r\nblue\r\n***\r\n***\r\n***\r\n***\r\n@@@\r\n@@@"
+      "\r\n@@@\r\n@@@");
+    auto sprite = SpriteParser::parseSprite("carriage.txt", "test_sprite");
+    assert_string("label is correct", sprite.getLabel(), "test_sprite");
+    assert_int("frame count is correct", sprite.getFrameCount(), 2);
+    assert_int("width is correct", sprite.getWidth(), 3);
+    assert_int("height is correct", sprite.getHeight(), 3);
+    assert_int("slowdown is correct", sprite.getSlowdown(), 2);
+    assert_int("color is correct", sprite.getColor(), BLUE);
+    remove("carriage.txt");
+  });
 }

--- a/test/suites/WorldManager_test.cpp
+++ b/test/suites/WorldManager_test.cpp
@@ -283,30 +283,30 @@ void WorldManager_outOfBounds_test() {
 }
 
 void WorldManager_objectManagement_test() {
-  auto obj1 = new Object;
-  auto obj2 = new Object;
-  auto obj3 = new Object;
-  auto obj4 = new Object;
+  Object obj1;
+  Object obj2;
+  Object obj3;
+  Object obj4;
 
-  obj3->setType("type");
-  obj4->setType("type");
+  obj3.setType("type");
+  obj4.setType("type");
 
   WM.startUp();
 
-  WM.insertObject(obj1);
-  WM.insertObject(obj2);
-  WM.insertObject(obj3);
-  WM.insertObject(obj4);
+  WM.insertObject(&obj1);
+  WM.insertObject(&obj2);
+  WM.insertObject(&obj3);
+  WM.insertObject(&obj4);
   WM.update();
 
   assert_int("has all the objects", WM.getAllObjects().getCount(), 4);
   assert_int("filters objects by type", WM.objectsOfType("type").getCount(), 2);
 
-  WM.markForDelete(obj1);
+  WM.markForDelete(&obj1);
   WM.update();
   assert_int("has one less object", WM.getAllObjects().getCount(), 3);
 
-  WM.removeObject(obj2);
+  WM.removeObject(&obj2);
   WM.update();
   assert_int("removes an object", WM.getAllObjects().getCount(), 2);
 

--- a/test/suites/WorldManager_test.cpp
+++ b/test/suites/WorldManager_test.cpp
@@ -5,6 +5,7 @@
 #include "../lib/test.h"
 #include "Box.h"
 #include "EventOut.h"
+#include "Object.h"
 #include "Vector.h"
 
 using namespace std;
@@ -283,30 +284,24 @@ void WorldManager_outOfBounds_test() {
 }
 
 void WorldManager_objectManagement_test() {
-  Object obj1;
-  Object obj2;
-  Object obj3;
-  Object obj4;
-
-  obj3.setType("type");
-  obj4.setType("type");
-
   WM.startUp();
+  array<Object*, 4> objects;
 
-  WM.insertObject(&obj1);
-  WM.insertObject(&obj2);
-  WM.insertObject(&obj3);
-  WM.insertObject(&obj4);
+  for (int i = 0; i < 4; i++) objects[i] = new Object;
+
+  objects[2]->setType("type");
+  objects[3]->setType("type");
+
   WM.update();
 
   assert_int("has all the objects", WM.getAllObjects().getCount(), 4);
   assert_int("filters objects by type", WM.objectsOfType("type").getCount(), 2);
 
-  WM.markForDelete(&obj1);
+  WM.markForDelete(objects[0]);
   WM.update();
   assert_int("has one less object", WM.getAllObjects().getCount(), 3);
 
-  WM.removeObject(&obj2);
+  WM.removeObject(objects[1]);
   WM.update();
   assert_int("removes an object", WM.getAllObjects().getCount(), 2);
 


### PR DESCRIPTION
This change should fix memory leaks in SpriteParser and Managers whereby sprite and events are dynamically allocated and never freed up. 